### PR TITLE
clean: imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,7 @@ select = [
     "NPY",
     # Print: Forbid print statements
     "T20",
+    "F",
 ]
 ignore = [
     # Allow self and cls to be untyped, and allow Any type

--- a/vicinity/backends/basic.py
+++ b/vicinity/backends/basic.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Literal, Union
+from typing import Any, Union
 
 import numpy as np
 from numpy import typing as npt

--- a/vicinity/backends/faiss.py
+++ b/vicinity/backends/faiss.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from typing import Any, Union
 
 import faiss
-import numpy as np
 from numpy import typing as npt
 
 from vicinity.backends.base import AbstractBackend, BaseArgs

--- a/vicinity/backends/hnsw.py
+++ b/vicinity/backends/hnsw.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Literal, Union
+from typing import Any, Union
 
 from hnswlib import Index as HnswIndex
 from numpy import typing as npt

--- a/vicinity/datatypes.py
+++ b/vicinity/datatypes.py
@@ -2,7 +2,6 @@ from enum import Enum
 from pathlib import Path
 from typing import Iterable, List, Tuple, Union
 
-import numpy as np
 from numpy import typing as npt
 
 PathLike = Union[str, Path]

--- a/vicinity/vicinity.py
+++ b/vicinity/vicinity.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import time
 from io import open
 from pathlib import Path
 from time import perf_counter


### PR DESCRIPTION
Weird: we had several unused imports, but those weren't flagged by any linters we have configured.

Turns out we were missing the 'F' rule. I added it, and removed the unused imports.