### PR TITLE
feat: make Metric the basic unit for metrics, not str

### DIFF
--- a/vicinity/backends/annoy.py
+++ b/vicinity/backends/annoy.py
@@ -16,7 +16,7 @@ from vicinity.utils import Metric, normalize
 @dataclass
 class AnnoyArgs(BaseArgs):
     dim: int = 0
-    metric: str = "cosine"
+    metric: Metric = Metric.COSINE
     trees: int = 100
     length: int | None = None
 
@@ -24,7 +24,7 @@ class AnnoyArgs(BaseArgs):
 class AnnoyBackend(AbstractBackend[AnnoyArgs]):
     argument_class = AnnoyArgs
     supported_metrics = {Metric.COSINE, Metric.EUCLIDEAN, Metric.INNER_PRODUCT}
-    inverse_metric_mapping = {
+    inverse_metric_mapping: dict[Metric, str] = {
         Metric.COSINE: "dot",
         Metric.EUCLIDEAN: "euclidean",
         Metric.INNER_PRODUCT: "dot",
@@ -62,12 +62,12 @@ class AnnoyBackend(AbstractBackend[AnnoyArgs]):
             vectors = normalize(vectors)
 
         dim = vectors.shape[1]
-        index = AnnoyIndex(f=dim, metric=metric)  # type: ignore
+        index = AnnoyIndex(f=dim, metric=metric)  # type: ignore  # Expects literal, but we just give str.
         for i, vector in enumerate(vectors):
             index.add_item(i, vector)
         index.build(trees)
 
-        arguments = AnnoyArgs(dim=dim, metric=metric, trees=trees, length=len(vectors))  # type: ignore
+        arguments = AnnoyArgs(dim=dim, metric=metric_enum, trees=trees, length=len(vectors))
         return AnnoyBackend(index, arguments=arguments)
 
     @property
@@ -88,8 +88,10 @@ class AnnoyBackend(AbstractBackend[AnnoyArgs]):
     def load(cls: type[AnnoyBackend], base_path: Path) -> AnnoyBackend:
         """Load the vectors from a path."""
         path = Path(base_path) / "index.bin"
+
         arguments = AnnoyArgs.load(base_path / "arguments.json")
-        index = AnnoyIndex(arguments.dim, arguments.metric)  # type: ignore
+        metric = cls._map_metric_to_string(arguments.metric)
+        index = AnnoyIndex(arguments.dim, metric)  # type: ignore
         index.load(str(path))
 
         return cls(index, arguments=arguments)
@@ -106,11 +108,11 @@ class AnnoyBackend(AbstractBackend[AnnoyArgs]):
         """Query the backend."""
         out = []
         for vec in vectors:
-            if self.arguments.metric == "dot":
+            if self.arguments.metric == Metric.COSINE:
                 vec = normalize(vec)
             indices, scores = self.index.get_nns_by_vector(vec, k, include_distances=True)
             scores_array = np.asarray(scores)
-            if self.arguments.metric == "dot":
+            if self.arguments.metric == Metric.COSINE:
                 # Convert cosine similarity to cosine distance
                 scores_array = 1 - scores_array
             out.append((np.asarray(indices), scores_array))

--- a/vicinity/backends/base.py
+++ b/vicinity/backends/base.py
@@ -14,19 +14,25 @@ from vicinity.datatypes import Backend, QueryResult
 
 @dataclass
 class BaseArgs:
+    metric: Metric
+
     def dump(self, file: Path) -> None:
         """Dump the arguments to a file."""
         with open(file, "w") as f:
-            json.dump(asdict(self), f)
+            d = self.dict()
+            d["metric"] = d["metric"].value
+            json.dump(d, f)
 
     @classmethod
     def load(cls: type[ArgType], file: Path) -> ArgType:
         """Load the arguments from a file."""
         with open(file, "r") as f:
-            return cls(**json.load(f))
+            data = json.load(f)
+            data["metric"] = Metric.from_string(data["metric"])
+            return cls(**data)
 
     def dict(self) -> dict[str, Any]:
-        """Dump the arguments to a string."""
+        """Dump the arguments to a dict."""
         return asdict(self)
 
 

--- a/vicinity/backends/basic.py
+++ b/vicinity/backends/basic.py
@@ -15,7 +15,7 @@ from vicinity.utils import Metric, normalize, normalize_or_copy
 
 @dataclass
 class BasicArgs(BaseArgs):
-    metric: str = "cosine"
+    metric: Metric = Metric.COSINE
 
 
 class BasicBackend(AbstractBackend[BasicArgs], ABC):
@@ -72,11 +72,10 @@ class BasicBackend(AbstractBackend[BasicArgs], ABC):
         if metric_enum not in cls.supported_metrics:
             raise ValueError(f"Metric '{metric_enum.value}' is not supported by BasicBackend.")
 
-        metric = metric_enum.value
-        arguments = BasicArgs(metric=metric)
-        if metric == "cosine":
+        arguments = BasicArgs(metric=metric_enum)
+        if metric_enum == Metric.COSINE:
             return CosineBasicBackend(vectors, arguments)
-        elif metric == "euclidean":
+        elif metric_enum == Metric.EUCLIDEAN:
             return EuclideanBasicBackend(vectors, arguments)
         else:
             raise ValueError(f"Unsupported metric: {metric}")
@@ -88,9 +87,9 @@ class BasicBackend(AbstractBackend[BasicArgs], ABC):
         arguments = BasicArgs.load(folder / "arguments.json")
         with open(path, "rb") as f:
             vectors = np.load(f)
-        if arguments.metric == "cosine":
+        if arguments.metric == Metric.COSINE:
             return CosineBasicBackend(vectors, arguments)
-        elif arguments.metric == "euclidean":
+        elif arguments.metric == Metric.EUCLIDEAN:
             return EuclideanBasicBackend(vectors, arguments)
         else:
             raise ValueError(f"Unsupported metric: {arguments.metric}")

--- a/vicinity/backends/faiss.py
+++ b/vicinity/backends/faiss.py
@@ -13,6 +13,8 @@ from vicinity.backends.base import AbstractBackend, BaseArgs
 from vicinity.datatypes import Backend, QueryResult
 from vicinity.utils import Metric, normalize
 
+FaissMetricType = Union[faiss.METRIC_INNER_PRODUCT, faiss.METRIC_L2]
+
 logger = logging.getLogger(__name__)
 
 # FAISS indexes that support range_search
@@ -37,7 +39,7 @@ TRAINABLE_INDEXES = (
 class FaissArgs(BaseArgs):
     dim: int = 0
     index_type: str = "flat"
-    metric: str = "cosine"
+    metric: Metric = Metric.COSINE
     nlist: int = 100
     m: int = 8
     nbits: int = 8
@@ -47,7 +49,7 @@ class FaissArgs(BaseArgs):
 class FaissBackend(AbstractBackend[FaissArgs]):
     argument_class = FaissArgs
     supported_metrics = {Metric.COSINE, Metric.EUCLIDEAN}
-    inverse_metric_mapping = {
+    inverse_metric_mapping: dict[Metric, FaissMetricType] = {
         Metric.COSINE: faiss.METRIC_INNER_PRODUCT,
         Metric.EUCLIDEAN: faiss.METRIC_L2,
     }
@@ -123,7 +125,7 @@ class FaissBackend(AbstractBackend[FaissArgs]):
         arguments = FaissArgs(
             dim=dim,
             index_type=index_type,
-            metric=metric_enum.value,
+            metric=metric_enum,
             nlist=nlist,
             m=m,
             nbits=nbits,

--- a/vicinity/backends/faiss.py
+++ b/vicinity/backends/faiss.py
@@ -13,8 +13,6 @@ from vicinity.backends.base import AbstractBackend, BaseArgs
 from vicinity.datatypes import Backend, QueryResult
 from vicinity.utils import Metric, normalize
 
-FaissMetricType = Union[faiss.METRIC_INNER_PRODUCT, faiss.METRIC_L2]
-
 logger = logging.getLogger(__name__)
 
 # FAISS indexes that support range_search
@@ -49,7 +47,7 @@ class FaissArgs(BaseArgs):
 class FaissBackend(AbstractBackend[FaissArgs]):
     argument_class = FaissArgs
     supported_metrics = {Metric.COSINE, Metric.EUCLIDEAN}
-    inverse_metric_mapping: dict[Metric, FaissMetricType] = {
+    inverse_metric_mapping = {
         Metric.COSINE: faiss.METRIC_INNER_PRODUCT,
         Metric.EUCLIDEAN: faiss.METRIC_L2,
     }

--- a/vicinity/backends/hnsw.py
+++ b/vicinity/backends/hnsw.py
@@ -15,7 +15,7 @@ from vicinity.utils import Metric
 @dataclass
 class HNSWArgs(BaseArgs):
     dim: int = 0
-    metric: str = "cosine"
+    metric: Metric = Metric.COSINE
     ef_construction: int = 200
     m: int = 16
 
@@ -58,7 +58,7 @@ class HNSWBackend(AbstractBackend[HNSWArgs]):
         index = HnswIndex(space=metric, dim=dim)
         index.init_index(max_elements=vectors.shape[0], ef_construction=ef_construction, M=m)
         index.add_items(vectors)
-        arguments = HNSWArgs(dim=dim, metric=metric, ef_construction=ef_construction, m=m)
+        arguments = HNSWArgs(dim=dim, metric=metric_enum, ef_construction=ef_construction, m=m)
         return HNSWBackend(index, arguments=arguments)
 
     @property
@@ -80,7 +80,8 @@ class HNSWBackend(AbstractBackend[HNSWArgs]):
         """Load the vectors from a path."""
         path = Path(base_path) / "index.bin"
         arguments = HNSWArgs.load(base_path / "arguments.json")
-        index = HnswIndex(space=arguments.metric, dim=arguments.dim)
+        mapped_metric = cls.inverse_metric_mapping[arguments.metric]
+        index = HnswIndex(space=mapped_metric, dim=arguments.dim)
         index.load_index(str(path))
         return cls(index, arguments=arguments)
 

--- a/vicinity/backends/pynndescent.py
+++ b/vicinity/backends/pynndescent.py
@@ -16,7 +16,7 @@ from vicinity.utils import Metric, normalize_or_copy
 @dataclass
 class PyNNDescentArgs(BaseArgs):
     n_neighbors: int = 15
-    metric: str = "cosine"
+    metric: Metric = Metric.COSINE
 
 
 class PyNNDescentBackend(AbstractBackend[PyNNDescentArgs]):
@@ -49,7 +49,7 @@ class PyNNDescentBackend(AbstractBackend[PyNNDescentArgs]):
         metric = metric_enum.value
 
         index = NNDescent(vectors, n_neighbors=n_neighbors, metric=metric, **kwargs)
-        arguments = PyNNDescentArgs(n_neighbors=n_neighbors, metric=metric)
+        arguments = PyNNDescentArgs(n_neighbors=n_neighbors, metric=metric_enum)
         return cls(index=index, arguments=arguments)
 
     def __len__(self) -> int:
@@ -105,10 +105,7 @@ class PyNNDescentBackend(AbstractBackend[PyNNDescentArgs]):
         arguments = PyNNDescentArgs.load(base_path / "arguments.json")
         vectors = np.load(Path(base_path) / "vectors.npy")
 
-        metric_enum = Metric.from_string(arguments.metric)
-        pynndescent_metric = metric_enum.value
-
-        index = NNDescent(vectors, n_neighbors=arguments.n_neighbors, metric=pynndescent_metric)
+        index = NNDescent(vectors, n_neighbors=arguments.n_neighbors, metric=arguments.metric.value)
 
         # Load the neighbor graph if it was saved
         neighbor_graph_path = base_path / "neighbor_graph.npy"

--- a/vicinity/backends/usearch.py
+++ b/vicinity/backends/usearch.py
@@ -16,7 +16,7 @@ from vicinity.utils import Metric
 @dataclass
 class UsearchArgs(BaseArgs):
     dim: int = 0
-    metric: str = "cos"
+    metric: Metric = Metric.COSINE
     connectivity: int = 16
     expansion_add: int = 128
     expansion_search: int = 64
@@ -67,10 +67,10 @@ class UsearchBackend(AbstractBackend[UsearchArgs]):
             expansion_add=expansion_add,
             expansion_search=expansion_search,
         )
-        index.add(keys=None, vectors=vectors)  # type: ignore
+        index.add(keys=None, vectors=vectors)  # type: ignore  # None keys are allowed but not typed
         arguments = UsearchArgs(
             dim=dim,
-            metric=metric,
+            metric=metric_enum,
             connectivity=connectivity,
             expansion_add=expansion_add,
             expansion_search=expansion_search,
@@ -99,7 +99,7 @@ class UsearchBackend(AbstractBackend[UsearchArgs]):
 
         index = UsearchIndex(
             ndim=arguments.dim,
-            metric=arguments.metric,
+            metric=cls._map_metric_to_string(arguments.metric),
             connectivity=arguments.connectivity,
             expansion_add=arguments.expansion_add,
             expansion_search=arguments.expansion_search,
@@ -122,7 +122,7 @@ class UsearchBackend(AbstractBackend[UsearchArgs]):
 
     def insert(self, vectors: npt.NDArray) -> None:
         """Insert vectors into the backend."""
-        self.index.add(None, vectors)  # type: ignore
+        self.index.add(None, vectors)  # type: ignore  # None keys are allowed, but not typed.
 
     def delete(self, indices: list[int]) -> None:
         """Delete vectors from the index (not supported by Usearch)."""


### PR DESCRIPTION
We used a string as the basic unit for all metrics, but we already have a really nice way of expressing which metrics we should use: the Metric Enum.

This PR changes all stored metrics to be Metric Enum values, and not backend-specific strings. This makes Enum values comparable over backends.