### PR TITLE
fix: issue with k > length in various backends

### DIFF
--- a/tests/test_vicinity.py
+++ b/tests/test_vicinity.py
@@ -58,6 +58,10 @@ def test_vicinity_query(vicinity_instance: Vicinity, query_vector: np.ndarray) -
 
     assert len(results) == 1
 
+    results = vicinity_instance.query(np.stack([query_vector, query_vector]), k=2)
+
+    assert results[0] == results[1]
+
 
 def test_vicinity_query_threshold(vicinity_instance: Vicinity, query_vector: np.ndarray) -> None:
     """
@@ -69,6 +73,10 @@ def test_vicinity_query_threshold(vicinity_instance: Vicinity, query_vector: np.
     results = vicinity_instance.query_threshold(query_vector, threshold=0.7)
 
     assert len(results) >= 1
+
+    results = vicinity_instance.query_threshold(np.stack([query_vector, query_vector]), threshold=0.7)
+
+    assert results[0] == results[1]
 
 
 def test_vicinity_insert(vicinity_instance: Vicinity, query_vector: np.ndarray) -> None:

--- a/vicinity/backends/faiss.py
+++ b/vicinity/backends/faiss.py
@@ -146,6 +146,7 @@ class FaissBackend(AbstractBackend[FaissArgs]):
 
     def query(self, vectors: npt.NDArray, k: int) -> QueryResult:
         """Perform a k-NN search in the FAISS index."""
+        k = min(len(self), k)
         if self.arguments.metric == "cosine":
             vectors = normalize(vectors)
         distances, indices = self.index.search(vectors, k)

--- a/vicinity/backends/hnsw.py
+++ b/vicinity/backends/hnsw.py
@@ -93,6 +93,7 @@ class HNSWBackend(AbstractBackend[HNSWArgs]):
 
     def query(self, vectors: npt.NDArray, k: int) -> QueryResult:
         """Query the backend."""
+        k = min(k, len(self))
         return list(zip(*self.index.knn_query(vectors, k)))
 
     def insert(self, vectors: npt.NDArray) -> None:

--- a/vicinity/backends/usearch.py
+++ b/vicinity/backends/usearch.py
@@ -115,9 +115,10 @@ class UsearchBackend(AbstractBackend[UsearchArgs]):
 
     def query(self, vectors: npt.NDArray, k: int) -> QueryResult:
         """Query the backend and return results as tuples of keys and distances."""
+        k = min(k, len(self))
         results = self.index.search(vectors, k)
-        keys = np.array(results.keys).reshape(-1, k)
-        distances = np.array(results.distances, dtype=np.float32).reshape(-1, k)
+        keys = np.atleast_2d(results.keys)
+        distances = np.atleast_2d(results.distances)
         return list(zip(keys, distances))
 
     def insert(self, vectors: npt.NDArray) -> None:

--- a/vicinity/backends/voyager.py
+++ b/vicinity/backends/voyager.py
@@ -68,6 +68,7 @@ class VoyagerBackend(AbstractBackend[VoyagerArgs]):
 
     def query(self, query: npt.NDArray, k: int) -> QueryResult:
         """Query the backend for the nearest neighbors."""
+        k = min(k, len(self))
         indices, distances = self.index.query(query, k)
         return list(zip(indices, distances))
 


### PR DESCRIPTION
This PR fixes an issue with extremely low item count and k. If k was higher than the number of items in the database, some backends would crash