### PR TITLE
Refactor README and Vicinity class to support any serializable item type

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,12 +81,14 @@ results = vicinity.query(query_vectors, k=3)
 ```
 
 Saving and loading a vector store:
+
 ```python
 vicinity.save('my_vector_store')
 vicinity = Vicinity.load('my_vector_store')
 ```
 
 Evaluating a backend:
+
 ```python
 # Use the first 1000 vectors as query vectors
 query_vectors = vectors[:1000]

--- a/README.md
+++ b/README.md
@@ -35,8 +35,7 @@ Vicinity is a light-weight, low-dependency vector store. It provides a simple an
 
 There are many nearest neighbors packages and methods out there. However, we found it difficult to compare them. Every package has its own interface, quirks, and limitations, and learning a new package can be time-consuming. In addition to that, how do you effectively evaluate different packages? How do you know which one is the best for your use case?
 
-
- This is where Vicinity comes in. Instead of learning a new interface for each new package or backend, Vicinity provides a unified interface for all backends. This allows you to easily experiment with different indexing methods and distance metrics and choose the best one for your use case. Vicinity also provides a simple way to evaluate the performance of different backends, allowing you to measure the queries per second and recall.
+This is where Vicinity comes in. Instead of learning a new interface for each new package or backend, Vicinity provides a unified interface for all backends. This allows you to easily experiment with different indexing methods and distance metrics and choose the best one for your use case. Vicinity also provides a simple way to evaluate the performance of different backends, allowing you to measure the queries per second and recall.
 
 ## Quickstart
 
@@ -49,13 +48,13 @@ Optionally, [install any of the supported backends](#installation), or simply in
 pip install vicinity[all]
 ```
 
-
 The following code snippet demonstrates how to use Vicinity for nearest neighbor search:
+
 ```python
 import numpy as np
 from vicinity import Vicinity, Backend, Metric
 
-# Create some dummy data
+# Create some dummy data as strings or other serializable objects
 items = ["triforce", "master sword", "hylian shield", "boomerang", "hookshot"]
 vectors = np.random.rand(len(items), 128)
 
@@ -100,6 +99,7 @@ qps, recall = vicinity.evaluate(
 ```
 
 ## Main Features
+
 Vicinity provides the following features:
 - Lightweight: Minimal dependencies and fast performance.
 - Flexible Backend Support: Use different backends for vector storage and search.
@@ -108,6 +108,7 @@ Vicinity provides the following features:
 - Easy to Use: Simple and intuitive API.
 
 ## Supported Backends
+
 The following backends are supported:
 - `BASIC`: A simple (exact matching) flat index for vector storage and search.
 - [HNSW](https://github.com/nmslib/hnswlib): Hierarchical Navigable Small World Graph (HNSW) for ANN search using hnswlib.
@@ -125,8 +126,6 @@ The following backends are supported:
   - `ivfpq`: Inverted file search with product quantizer.
   - `ivfpqr`: Inverted file search with product quantizer and refinement.
 - [VOYAGER](https://github.com/spotify/voyager): Voyager is a library for performing fast approximate nearest-neighbor searches on an in-memory collection of vectors.
-
-
 
 NOTE: the ANN backends do not support dynamic deletion. To delete items, you need to recreate the index. Insertion is supported in the following backends: `FAISS`, `HNSW`, and `Usearch`. The `BASIC` backend supports both insertion and deletion.
 
@@ -159,7 +158,9 @@ NOTE: the ANN backends do not support dynamic deletion. To delete items, you nee
 |                 | `m`                 | The number of connections between nodes in the tree’s internal data structure.                                                              | `16`                |
 
 ## Installation
+
 The following installation options are available:
+
 ```bash
 # Install the base package
 pip install vicinity

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,7 @@ _faiss_index_types = [
 @pytest.fixture(scope="session")
 def items() -> list[str]:
     """Fixture providing a list of item names."""
-    return [f"item{i}" for i in range(1, 10001)]
+    return [f"item{i}" if i % 2 == 0 else {"name": f"item{i}", "id": i} for i in range(1, 10001)]
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,18 @@ def items() -> list[str]:
 
 
 @pytest.fixture(scope="session")
+def non_serializable_items() -> list[str]:
+    """Fixture providing a list of non-serializable items."""
+
+    class NonSerializable:
+        def __init__(self, name: str, id: int) -> None:
+            self.name = name
+            self.id = id
+
+    return [NonSerializable(f"item{i}", i) for i in range(1, 10001)]
+
+
+@pytest.fixture(scope="session")
 def vectors() -> np.ndarray:
     """Fixture providing an array of vectors corresponding to items."""
     return random_gen.random((10000, 8))

--- a/tests/test_vicinity.py
+++ b/tests/test_vicinity.py
@@ -183,18 +183,17 @@ def test_index_vector_store(vicinity_with_basic_backend_and_store: Vicinity, vec
         vicinity_with_basic_backend_and_store.get_vector_by_index([-1])
 
 
-def test_vicinity_insert_duplicate(vicinity_instance: Vicinity, query_vector: np.ndarray) -> None:
+def test_vicinity_insert_duplicate(items: list[str], vicinity_instance: Vicinity, query_vector: np.ndarray) -> None:
     """
     Test that Vicinity.insert raises ValueError when inserting duplicate items.
 
     :param vicinity_instance: A Vicinity instance.
     :raises ValueError: If inserting items that already exist.
     """
-    new_items = ["item1"]
     new_vector = query_vector
 
     with pytest.raises(ValueError):
-        vicinity_instance.insert(new_items, new_vector[None, :])
+        vicinity_instance.insert(items[0], new_vector[None, :])
 
 
 def test_vicinity_delete_nonexistent(vicinity_instance: Vicinity) -> None:
@@ -281,7 +280,8 @@ def test_vicinity_delete_and_query(vicinity_instance: Vicinity, items: list[str]
         return
 
     # Delete some items from the Vicinity instance
-    items_to_delete = ["item2", "item4", "item6"]
+    non_existing_items_indices = [0, 1, 2]
+    items_to_delete = [items[i] for i in non_existing_items_indices]
     vicinity_instance.delete(items_to_delete)
 
     # Ensure the items are no longer in the items list
@@ -289,14 +289,14 @@ def test_vicinity_delete_and_query(vicinity_instance: Vicinity, items: list[str]
         assert item not in vicinity_instance.items
 
     # Query using a vector of an item that wasn't deleted
-    item3_index = items.index("item3")
-    item3_vector = vectors[item3_index]
+    existsing_item_index = 3
+    item3_vector = vectors[existsing_item_index]
 
     results = vicinity_instance.query(item3_vector, k=10)
     returned_items = [item for item, _ in results[0]]
 
     # Check that the queried item is in the results
-    assert "item3" in returned_items
+    assert items[existsing_item_index] in returned_items
 
 
 def test_vicinity_evaluate(vicinity_instance: Vicinity, vectors: np.ndarray) -> None:

--- a/tests/test_vicinity.py
+++ b/tests/test_vicinity.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import numpy as np
 import pytest
+from orjson import JSONEncodeError
 
 from vicinity import Vicinity
 from vicinity.datatypes import Backend
@@ -160,6 +161,21 @@ def test_vicinity_save_and_load_vector_store(tmp_path: Path, vicinity_instance_w
 
     v = Vicinity.load(save_path)
     assert v.vector_store is not None
+
+
+def test_vicinity_save_and_load_non_serializable_items(
+    tmp_path: Path, non_serializable_items: list[str], vectors: np.ndarray
+) -> None:
+    """
+    Test Vicinity.save and Vicinity.load with non-serializable items.
+
+    :param tmp_path: Temporary directory provided by pytest.
+    :param non_serializable_items: A list of non-serializable items.
+    """
+    vicinity = Vicinity.from_vectors_and_items(vectors=vectors, items=non_serializable_items)
+    save_path = tmp_path / "vicinity_data"
+    with pytest.raises(JSONEncodeError):
+        vicinity.save(save_path)
 
 
 def test_index_vector_store(vicinity_with_basic_backend_and_store: Vicinity, vectors: np.ndarray) -> None:

--- a/tests/test_vicinity.py
+++ b/tests/test_vicinity.py
@@ -289,14 +289,14 @@ def test_vicinity_delete_and_query(vicinity_instance: Vicinity, items: list[str]
         assert item not in vicinity_instance.items
 
     # Query using a vector of an item that wasn't deleted
-    existsing_item_index = 3
-    item3_vector = vectors[existsing_item_index]
+    existing_item_index = 3
+    item3_vector = vectors[existing_item_index]
 
     results = vicinity_instance.query(item3_vector, k=10)
     returned_items = [item for item, _ in results[0]]
 
     # Check that the queried item is in the results
-    assert items[existsing_item_index] in returned_items
+    assert items[existing_item_index] in returned_items
 
 
 def test_vicinity_evaluate(vicinity_instance: Vicinity, vectors: np.ndarray) -> None:

--- a/vicinity/vicinity.py
+++ b/vicinity/vicinity.py
@@ -256,15 +256,17 @@ class Vicinity:
         :param tokens: A list of tokens to remove from the vector space.
         :raises ValueError: If any passed tokens are not in the vector space.
         """
-        seen_tokens = []
+        tokens_to_find = list(tokens)
         curr_indices = []
         for idx, elem in enumerate(self.items):
-            for token in tokens:
-                if elem == token:
-                    curr_indices.append(idx)
-                    seen_tokens.append(token)
-        if len(seen_tokens) < len(tokens):
-            raise ValueError("Not all tokens were in the vector space.")
+            matching_tokens = [t for t in tokens_to_find if t == elem]
+            if matching_tokens:
+                curr_indices.append(idx)
+                for t in matching_tokens:
+                    tokens_to_find.remove(t)
+
+        if tokens_to_find:
+            raise ValueError(f"Tokens {tokens_to_find} were not in the vector space.")
 
         self.backend.delete(curr_indices)
         if self.vector_store is not None:

--- a/vicinity/vicinity.py
+++ b/vicinity/vicinity.py
@@ -241,11 +241,7 @@ class Vicinity:
         if vectors.shape[1] != self.dim:
             raise ValueError("The inserted vectors must have the same dimension as the backend.")
 
-        for token in tokens:
-            for item in self.items:
-                if item == token:
-                    raise ValueError(f"Token {token} is already in the vector space.")
-            self.items.append(token)
+        self.items.extend(tokens)
         self.backend.insert(vectors)
         if self.vector_store is not None:
             self.vector_store.insert(vectors)

--- a/vicinity/vicinity.py
+++ b/vicinity/vicinity.py
@@ -11,6 +11,7 @@ from typing import Any, Iterable, Sequence, Union
 import numpy as np
 import orjson
 from numpy import typing as npt
+from orjson import JSONEncodeError
 
 from vicinity import Metric
 from vicinity.backends import AbstractBackend, BasicBackend, BasicVectorStore, get_backend_class
@@ -185,9 +186,11 @@ class Vicinity:
             raise ValueError(f"Path {path} should be a directory.")
 
         items_dict = {"items": self.items, "metadata": self.metadata, "backend_type": self.backend.backend_type.value}
-
-        with open(path / "data.json", "wb") as file_handle:
-            file_handle.write(orjson.dumps(items_dict))
+        try:
+            with open(path / "data.json", "wb") as file_handle:
+                file_handle.write(orjson.dumps(items_dict))
+        except JSONEncodeError as e:
+            raise JSONEncodeError(f"Items could not be encoded to JSON because they are not serializable: {e}")
 
         self.backend.save(path)
         if self.vector_store is not None:

--- a/vicinity/vicinity.py
+++ b/vicinity/vicinity.py
@@ -178,6 +178,7 @@ class Vicinity:
         :param folder: The path to which to save the JSON file. The vectors are saved separately. The JSON contains a path to the numpy file.
         :param overwrite: Whether to overwrite the JSON and numpy files if they already exist.
         :raises ValueError: If the path is not a directory.
+        :raises JSONEncodeError: If the items are not serializable.
         """
         path = Path(folder)
         path.mkdir(parents=True, exist_ok=overwrite)

--- a/vicinity/vicinity.py
+++ b/vicinity/vicinity.py
@@ -243,15 +243,10 @@ class Vicinity:
 
         item_set = set(self.items)
         for token in tokens:
-            if isinstance(token, str):
-                if token in item_set:
+            for item in item_set:
+                if item == token:
                     raise ValueError(f"Token {token} is already in the vector space.")
-                self.items.append(token)
-            else:
-                for item in self.items:
-                    if item == token:
-                        raise ValueError(f"Token {token} is already in the vector space.")
-                self.items.append(token)
+            self.items.append(token)
         self.backend.insert(vectors)
         if self.vector_store is not None:
             self.vector_store.insert(vectors)
@@ -267,13 +262,10 @@ class Vicinity:
         :raises ValueError: If any passed tokens are not in the vector space.
         """
         try:
-            if isinstance(tokens[0], str):
-                curr_indices = [self.items.index(token) for token in tokens]
-            else:
-                curr_indices = []
-                for idx, elem in enumerate(self.items):
-                    if elem in tokens:
-                        curr_indices.append(idx)
+            curr_indices = []
+            for idx, elem in enumerate(self.items):
+                if elem in tokens:
+                    curr_indices.append(idx)
         except ValueError as exc:
             raise ValueError(f"Token {exc} was not in the vector space.") from exc
 

--- a/vicinity/vicinity.py
+++ b/vicinity/vicinity.py
@@ -241,9 +241,8 @@ class Vicinity:
         if vectors.shape[1] != self.dim:
             raise ValueError("The inserted vectors must have the same dimension as the backend.")
 
-        item_set = set(self.items)
         for token in tokens:
-            for item in item_set:
+            for item in self.items:
                 if item == token:
                     raise ValueError(f"Token {token} is already in the vector space.")
             self.items.append(token)
@@ -261,13 +260,15 @@ class Vicinity:
         :param tokens: A list of tokens to remove from the vector space.
         :raises ValueError: If any passed tokens are not in the vector space.
         """
-        try:
-            curr_indices = []
-            for idx, elem in enumerate(self.items):
-                if elem in tokens:
+        seen_tokens = []
+        curr_indices = []
+        for idx, elem in enumerate(self.items):
+            for token in tokens:
+                if elem == token:
                     curr_indices.append(idx)
-        except ValueError as exc:
-            raise ValueError(f"Token {exc} was not in the vector space.") from exc
+                    seen_tokens.append(token)
+        if len(seen_tokens) < len(tokens):
+            raise ValueError("Not all tokens were in the vector space.")
 
         self.backend.delete(curr_indices)
         if self.vector_store is not None:


### PR DESCRIPTION
I was playing around and realised the items don't necessarily need to be strings.

**Update**

- Updated README.md to clarify that items can be strings or other serialisable objects.
- Modified the Vicinity class to accept a broader range of item types by changing type hints from `str` to `Any` in several methods.
- Enhanced the insert and delete methods to handle non-string tokens appropriately, ensuring that items can be checked and managed regardless of their type.

**Question**
Also, why do we use tokens as argument names for items in the insert and delete methods?

**Example**
Something like the following works now. Slower during insert and deletion but I would say the flexibility is worth it.

```python
import numpy as np

from vicinity import Backend, Metric, Vicinity

# Create some dummy data
items = [
    {"name": "triforce", "id": 0},
    {"name": "master sword", "id": 1},
    {"name": "hylian shield", "id": 2},
    {"name": "boomerang", "id": 3},
    {"name": "hookshot", "id": 4},
]


vectors = np.random.rand(len(items), 128)

# Initialize the Vicinity instance (using the basic backend and cosine metric)
vicinity = Vicinity.from_vectors_and_items(
    vectors=vectors, items=items, backend_type=Backend.BASIC, metric=Metric.COSINE
)

# Create a query vector
query_vector = np.random.rand(128)

# Query for nearest neighbors with a top-k search
results = vicinity.query(query_vector, k=3)

# Query for nearest neighbors with a threshold search
results = vicinity.query_threshold(query_vector, threshold=0.9)

vicinity.delete([items[0], items[1], items[2], items[3], items[4]])
vicinity.insert(items, vectors)
# Query with a list of query vectors
query_vectors = np.random.rand(5, 128)
results = vicinity.query(query_vectors, k=3)
print(results)

vicinity.save("my_vector_store", overwrite=True)
vicinity = Vicinity.load("my_vector_store")

results = vicinity.query(query_vectors, k=3)
print(results)
```
