### PR TITLE
feat: Make vicinity typing generic

### DIFF
--- a/vicinity/datatypes.py
+++ b/vicinity/datatypes.py
@@ -1,12 +1,13 @@
 from collections.abc import Iterable
 from enum import Enum
 from pathlib import Path
+from typing import Any
 
 from numpy import typing as npt
 
 PathLike = str | Path
 Matrix = npt.NDArray | list[npt.NDArray]
-SimilarityItem = list[tuple[str, float]]
+SimilarityItem = list[tuple[Any, float]]
 SimilarityResult = list[SimilarityItem]
 # Tuple of (indices, distances)
 SingleQueryResult = tuple[npt.NDArray, npt.NDArray]

--- a/vicinity/datatypes.py
+++ b/vicinity/datatypes.py
@@ -1,14 +1,16 @@
 from collections.abc import Iterable
 from enum import Enum
 from pathlib import Path
-from typing import Any
+from typing import TypeVar
 
 from numpy import typing as npt
 
+T = TypeVar("T")
+
 PathLike = str | Path
 Matrix = npt.NDArray | list[npt.NDArray]
-SimilarityItem = list[tuple[Any, float]]
-SimilarityResult = list[SimilarityItem]
+SimilarityItem = list[tuple[T, float]]
+SimilarityResult = list[list[tuple[T, float]]]
 # Tuple of (indices, distances)
 SingleQueryResult = tuple[npt.NDArray, npt.NDArray]
 QueryResult = list[SingleQueryResult]

--- a/vicinity/vicinity.py
+++ b/vicinity/vicinity.py
@@ -6,9 +6,7 @@ import logging
 from collections.abc import Iterable, Sequence
 from pathlib import Path
 from time import perf_counter
-from typing import Any, Generic, TypeVar
-
-T = TypeVar("T")
+from typing import Any, Generic
 
 import numpy as np
 import orjson
@@ -17,7 +15,7 @@ from orjson import JSONEncodeError
 
 from vicinity import Metric
 from vicinity.backends import AbstractBackend, BasicBackend, BasicVectorStore, get_backend_class
-from vicinity.datatypes import Backend, PathLike
+from vicinity.datatypes import Backend, PathLike, SimilarityResult, T
 
 logger = logging.getLogger(__name__)
 
@@ -117,7 +115,7 @@ class Vicinity(Generic[T]):
         self,
         vectors: npt.NDArray,
         k: int = 10,
-    ) -> list[list[tuple[T, float]]]:
+    ) -> SimilarityResult[T]:
         """
         Find the nearest neighbors to some arbitrary vector.
 
@@ -144,7 +142,7 @@ class Vicinity(Generic[T]):
         vectors: npt.NDArray,
         threshold: float = 0.5,
         max_k: int = 100,
-    ) -> list[list[tuple[T, float]]]:
+    ) -> SimilarityResult[T]:
         """
         Find the nearest neighbors to some arbitrary vector with some threshold. Note: the output is not sorted.
 

--- a/vicinity/vicinity.py
+++ b/vicinity/vicinity.py
@@ -6,7 +6,9 @@ import logging
 from collections.abc import Iterable, Sequence
 from pathlib import Path
 from time import perf_counter
-from typing import Any
+from typing import Any, Generic, TypeVar
+
+T = TypeVar("T")
 
 import numpy as np
 import orjson
@@ -15,12 +17,12 @@ from orjson import JSONEncodeError
 
 from vicinity import Metric
 from vicinity.backends import AbstractBackend, BasicBackend, BasicVectorStore, get_backend_class
-from vicinity.datatypes import Backend, PathLike, SimilarityResult
+from vicinity.datatypes import Backend, PathLike
 
 logger = logging.getLogger(__name__)
 
 
-class Vicinity:
+class Vicinity(Generic[T]):
     """
     Work with vector representations of items.
 
@@ -30,7 +32,7 @@ class Vicinity:
 
     def __init__(
         self,
-        items: Sequence[Any],
+        items: Sequence[T],
         backend: AbstractBackend,
         metadata: dict[str, Any] | None = None,
         vector_store: BasicVectorStore | None = None,
@@ -50,7 +52,7 @@ class Vicinity:
             raise ValueError(
                 "Your vector space and list of items are not the same length: " f"{len(backend)} != {len(items)}"
             )
-        self.items: list[Any] = list(items)
+        self.items: list[T] = list(items)
         self.backend: AbstractBackend = backend
         self.metadata = metadata or {}
         self.vector_store = vector_store
@@ -73,13 +75,13 @@ class Vicinity:
 
     @classmethod
     def from_vectors_and_items(
-        cls: type[Vicinity],
+        cls: type[Vicinity[T]],
         vectors: npt.NDArray,
-        items: Sequence[Any],
+        items: Sequence[T],
         backend_type: Backend | str = Backend.BASIC,
         store_vectors: bool = False,
         **kwargs: Any,
-    ) -> Vicinity:
+    ) -> Vicinity[T]:
         """
         Create a Vicinity instance from vectors and items.
 
@@ -115,7 +117,7 @@ class Vicinity:
         self,
         vectors: npt.NDArray,
         k: int = 10,
-    ) -> SimilarityResult:
+    ) -> list[list[tuple[T, float]]]:
         """
         Find the nearest neighbors to some arbitrary vector.
 
@@ -142,7 +144,7 @@ class Vicinity:
         vectors: npt.NDArray,
         threshold: float = 0.5,
         max_k: int = 100,
-    ) -> SimilarityResult:
+    ) -> list[list[tuple[T, float]]]:
         """
         Find the nearest neighbors to some arbitrary vector with some threshold. Note: the output is not sorted.
 
@@ -178,7 +180,9 @@ class Vicinity:
         :param folder: The path to which to save the JSON file. The vectors are saved separately. The JSON contains a path to the numpy file.
         :param overwrite: Whether to overwrite the JSON and numpy files if they already exist.
         :raises ValueError: If the path is not a directory.
-        :raises JSONEncodeError: If the items are not serializable.
+        :raises JSONEncodeError: If the items are not JSON-serializable. ``save()`` and ``load()``
+            only support item types that orjson can encode (e.g. strings, numbers, dicts).
+            Use ``Vicinity[str]`` or another serializable type if you need persistence.
         """
         path = Path(folder)
         path.mkdir(parents=True, exist_ok=overwrite)
@@ -200,7 +204,7 @@ class Vicinity:
             self.vector_store.save(store_path)
 
     @classmethod
-    def load(cls, filename: PathLike) -> Vicinity:
+    def load(cls, filename: PathLike) -> Vicinity[Any]:
         """
         Load a Vicinity instance in fast format.
 
@@ -231,7 +235,7 @@ class Vicinity:
 
         return instance
 
-    def insert(self, tokens: Sequence[Any], vectors: npt.NDArray) -> None:
+    def insert(self, tokens: Sequence[T], vectors: npt.NDArray) -> None:
         """
         Insert new items into the vector space.
 
@@ -250,7 +254,7 @@ class Vicinity:
         if self.vector_store is not None:
             self.vector_store.insert(vectors)
 
-    def delete(self, tokens: Sequence[Any]) -> None:
+    def delete(self, tokens: Sequence[T]) -> None:
         """
         Delete tokens from the vector space.
 
@@ -309,7 +313,7 @@ class Vicinity:
         )
 
     @classmethod
-    def load_from_hub(cls: type[Vicinity], repo_id: str, token: str | None = None, **kwargs: Any) -> Vicinity:
+    def load_from_hub(cls: type[Vicinity[Any]], repo_id: str, token: str | None = None, **kwargs: Any) -> Vicinity[Any]:
         """
         Load a Vicinity instance from the Hugging Face Hub.
 


### PR DESCRIPTION
 Vicinity has always accepted any item type at runtime, but the type for `SimilarityItem` was hardcoded to `list[tuple[str, float]]`, making `query()` appear to return string items regardless of what was actually stored. This makes it impossible to use Vicinity with typed item types without resorting to cast() or type: ignore. This PR fixes that by changing the return type to a generic type.

For example, the following now works correctly:
```python
from dataclasses import dataclass                                                         
from vicinity import Vicinity                                                             
import numpy as np                                                                      
                                                                                        
@dataclass                                                                              
class Document:
    title: str
    url: str
                                                                                        
docs = [Document("Cats", "/cats"), Document("Dogs", "/dogs")]                   
vectors = np.random.rand(2, 4).astype(np.float32)                                         
                                                                                        
index: Vicinity[Document] = Vicinity.from_vectors_and_items(vectors, docs)              
query = np.random.rand(1, 4).astype(np.float32)
                                                                                        
hits = index.query(query, k=1)[0]  # list[tuple[Document, float]]
for doc, distance in hits:                                                                
    print(doc.url)  # this would have failed before with a type error since doc was always assumed to be a str
```